### PR TITLE
Piece/board structure overhaul

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,16 +6,11 @@
     <title>Chess Grandmaster's Arena</title>
     <link rel="stylesheet" href="./src/css/style.css" />
     <link rel="icon" href="./src/assets/favicon.ico" type="image/x-icon" />
-
-    <script src="./src/js/board.js"></script>
-    <script src="./src/js/pieces.js"></script>
-    <script src="./src/js/main.js"></script>
   </head>
   <body>
     <div id="app"><!-- JS-generated HTML --></div>
-
-    <script>
-      main();
-    </script>
+    <script src="./src/js/board.js"></script>
+    <script src="./src/js/pieces.js"></script>
+    <script src="./src/js/main.js"></script>
   </body>
 </html>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1,23 +1,49 @@
+:root {
+    --light-tile-bg: hsl(32, 42%, 69%);
+    --dark-tile-bg: hsl(26, 35%, 14%);
+    --bg-color: hsl(0, 0%, 81%);
+    --tile-size: 100px;
+    user-select: none;
+}
+
 body {
-    margin: 1rem; padding: 1em; background-color: rgb(206, 206, 206);
+    margin: 1rem;
+    padding: 1em;
+    background-color: var(--bg-color);
 }
 
 #app {
     display: grid;
-    grid-template-columns: repeat(8, 100px);
-    grid-template-rows: repeat(8, 100px);
+    grid-template-columns: repeat(8, var(--tile-size));
+    grid-template-rows: repeat(8, var(--tile-size));
 }
 
-.lightSquare,
-.darkSquare {
+.tile {
     font-size: 450%;
     text-align: center;
+    background-color: var(--dark-tile-bg);
+}
+.tile:nth-child(even) {
+    background-color: var(--light-tile-bg);
 }
 
-.lightSquare {
-    background-color: rgb(222, 187, 187);
+.white {
+    text-shadow: 2px 2px 0 black, 2px -2px 0 black, -2px -2px 0 black,
+        -2px 2px 0 black, 2px 0 0 black, 0 -2px 0 black, -2px 0 0 black,
+        0 2px 0 black;
+    color: hsl(0, 0%, 100%);
 }
 
-.darkSquare {
-    background-color: darkgrey;
+.odd {
+    background-color: var(--light-tile-bg);
+}
+
+.odd:nth-child(even) {
+    background-color: var(--dark-tile-bg);
+}
+
+.black {
+    text-shadow: 1px 1px 0 white, 1px -1px 0 white, -1px -1px 0 white,
+        -1px 1px 0 white;
+    color: hsl(0, 0%, 0%);
 }

--- a/src/js/board.js
+++ b/src/js/board.js
@@ -1,29 +1,77 @@
 function drawBoard() {
-    board = document.getElementById('app')
+    board = document.getElementById("app");
     let shift = 0;
-    for (let i=0; i<64; i++) {
-        let color = 'lightSquare';
+    for (let i = 0; i < 64; i++) {
+        let color = "lightSquare";
         if (i % 8 === 0) {
             shift++;
         }
-        if ((i+shift) % 2 === 0) {
-            color =  'darkSquare';
+        if ((i + shift) % 2 === 0) {
+            color = "darkSquare";
         }
-        board.innerHTML += `<div id="square${i}" class="${color}"></div>`; 
+        board.innerHTML += `<div id="square${i}" class="${color}"></div>`;
     }
 }
 
 function drawPiece(index, color, piece) {
     document.getElementById(`square${index}`).innerHTML = piece;
     document.getElementById(`square${index}`).style.color = color;
-    if (color === 'black') {
-        document.getElementById(`square${index}`).style.textShadow = `1px 1px white`;
+    if (color === "black") {
+        document.getElementById(
+            `square${index}`
+        ).style.textShadow = `1px 1px white`;
     } else {
-        document.getElementById(`square${index}`).style.textShadow = `1px 1px black`;
+        document.getElementById(
+            `square${index}`
+        ).style.textShadow = `1px 1px black`;
     }
-
 }
 
 function drawBlank(index) {
-    document.getElementById(`square${index}`).innerHTML = '';
+    document.getElementById(`square${index}`).innerHTML = "";
+}
+
+function createBackline(y, color) {
+    return [
+        new Rook(0, y, color),
+        new Knight(1, y, color),
+        new Bishop(2, y, color),
+        new Queen(3, y, color),
+        new King(4, y, color),
+        new Bishop(5, y, color),
+        new Knight(6, y, color),
+        new Rook(7, y, color),
+    ];
+}
+
+function createPawns(y, color) {
+    const pawns = [];
+    const BOARD_LENGTH = 8;
+    for (let i = 0; i < BOARD_LENGTH; i++) {
+        pawns.push(new Pawn(i, y, color));
+    }
+    return pawns;
+}
+
+function createStartingPosition() {
+    const blackBackline = createBackline(0, "black");
+    const blackPawns = createPawns(1, "black");
+    const whiteBackline = createBackline(7, "white");
+    const whitePawns = createPawns(6, "white");
+    const newBoard = [];
+    for (let row = 0; row < 8; row++) {
+        if (row === 0) {
+            newBoard.push(blackBackline);
+        } else if (row === 1) {
+            newBoard.push(blackPawns);
+        } else if (row === 6) {
+            newBoard.push(whitePawns);
+        } else if (row === 7) {
+            newBoard.push(whiteBackline);
+        } else {
+            newBoard.push(new Array(8).fill(null));
+        }
+    }
+    console.log(newBoard);
+    return newBoard;
 }

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,16 +1,37 @@
-
 // model
-let setStartPosition = true;
-let currentPosition = {};
+const app = document.getElementById("app");
+let currentPosition = [];
+let tilesCreated = false;
 
 // view
 function updateView() {
-    if (setStartPosition) {
-        drawBoard();
-        currentPosition = generateStartPosition();
-        setStartPosition = false;
-    }
     drawCurrentPosition();
+}
+
+function createIdString(row, col) {
+    return `${row}-${col}`;
+}
+
+function createTilesHTML() {
+    for (let row = 0; row < currentPosition.length; row++) {
+        for (let col = 0; col < currentPosition[0].length; col++) {
+            tile = document.createElement("div");
+            tile.id = createIdString(row, col);
+            tile.classList.add("tile");
+            if (row % 2) tile.classList.add("odd");
+            tile.addEventListener("mousedown", () => {
+                if (currentPosition[row][col]) {
+                    console.log(currentPosition[row][col].getPossibleMoves());
+                }
+            });
+            app.append(tile);
+        }
+    }
+    tilesCreated = true;
+}
+
+function getTileElement(row, col) {
+    return document.getElementById(`${row}-${col}`);
 }
 
 // controller
@@ -20,31 +41,41 @@ function movePiece() {
 
 // helper
 function drawCurrentPosition() {
-    /* 
-     * A dictionary holds the position data for each square.
-     * Each entry is shaped like shown below.
+    /*
+     * A 2D array holds the position data for each square.
+     * Each element in the array contains one of two options:
      *
-     *  currentPosition = {
-     *      0: {'player': 'black', 'piece': 'rook'},
-     *      1: {'player': 'black', 'piece': 'knight'},
-     *      3: {..},
-     *     32: {'player': 'none'},
-     *     33: {..},
-     *     62: {'player': 'white', 'piece': 'knight'},
-     *     63: {'player': 'white', 'piece': 'rook'},
-     *  }
+     *      If there is no piece, the element is null.
      *
+     *      If there is a piece, the element is an instance of a subclass
+     *      of Piece corresponding to the piece in the square.
+     *
+     * Each instance of Piece has its own getPossibleMoves method.
+     * This method is attached to an event listener.
      */
-    for (const [index, data] of Object.entries(currentPosition)) {
-        if (data['player'] === 'none') {
-            drawBlank(index);
-        } else {
-            drawPiece(index, data['player'], getUnicodePiece(data['piece']));
+
+    if (!tilesCreated) {
+        createTilesHTML();
+    }
+    for (let row = 0; row < currentPosition.length; row++) {
+        for (let col = 0; col < currentPosition[0].length; col++) {
+            currentPiece = currentPosition[row][col];
+            if (currentPiece) {
+                const currentTile = getTileElement(row, col);
+                const pieceText = currentPiece.symbol;
+                const IS_WHITE = currentPiece.color === "white";
+                const IS_BLACK = !IS_WHITE;
+                currentTile.textContent = pieceText;
+                currentTile.classList.toggle("white", IS_WHITE);
+                currentTile.classList.toggle("black", IS_BLACK);
+            }
         }
     }
 }
 
-// entrypoint
-function main() {
+function initApp() {
+    currentPosition = createStartingPosition();
     updateView();
 }
+
+document.addEventListener("DOMContentLoaded", initApp);

--- a/src/js/pieces.js
+++ b/src/js/pieces.js
@@ -5,40 +5,184 @@ const UNICODE_PIECES = {
     pawn: "♟",
     queen: "♛",
     rook: "♜",
-    none: "o",
 };
 
-function getUnicodePiece(piece) {
-    return UNICODE_PIECES[piece];
+const UP = { x: 0, y: -1 };
+const DOWN = { x: 0, y: 1 };
+const LEFT = { x: -1, y: 0 };
+const RIGHT = { x: 1, y: 0 };
+const DIAGONAL_UP_LEFT = { x: -1, y: -1 };
+const DIAGONAL_UP_RIGHT = { x: 1, y: -1 };
+const DIAGONAL_DOWN_LEFT = { x: -1, y: 1 };
+const DIAGONAL_DOWN_RIGHT = { x: 1, y: 1 };
+const KNIGHT_UP_LEFT = { x: -1, y: -2 };
+const KNIGHT_UP_RIGHT = { x: 1, y: -2 };
+const KNIGHT_DOWN_LEFT = { x: -1, y: 2 };
+const KNIGHT_DOWN_RIGHT = { x: 1, y: 2 };
+const KNIGHT_LEFT_UP = { x: -2, y: -1 };
+const KNIGHT_LEFT_DOWN = { x: -2, y: 1 };
+const KNIGHT_RIGHT_UP = { x: 2, y: -1 };
+const KNIGHT_RIGHT_DOWN = { x: 2, y: 1 };
+
+class Piece {
+    x;
+    y;
+    color;
+    constructor(x, y, color) {
+        this.x = x;
+        this.y = y;
+        this.color = color;
+    }
+    getPosition() {
+        return { x: this.x, y: this.y };
+    }
+    isOutOfBounds(x, y) {
+        if (x < 0 || x > 7 || y < 0 || y > 7) return true;
+        return false;
+    }
 }
 
-function generateStartPosition() {
-    // hardcoded for now, but can probably shorten this..
-    let currentPosition = {};
-    currentPosition[0] = { player: "black", piece: "rook" };
-    currentPosition[1] = { player: "black", piece: "knight" };
-    currentPosition[2] = { player: "black", piece: "bishop" };
-    currentPosition[3] = { player: "black", piece: "queen" };
-    currentPosition[4] = { player: "black", piece: "king" };
-    currentPosition[5] = { player: "black", piece: "bishop" };
-    currentPosition[6] = { player: "black", piece: "knight" };
-    currentPosition[7] = { player: "black", piece: "rook" };
-    for (i = 8; i < 16; i++) {
-        currentPosition[i] = { player: "black", piece: "pawn" };
+class Rook extends Piece {
+    symbol = UNICODE_PIECES.rook;
+    getPossibleMoves() {
+        const possibleMoves = [];
+        const directions = [UP, DOWN, LEFT, RIGHT];
+
+        const MIN_MOVES = 1;
+        const MAX_MOVES = 8;
+
+        for (let i = MIN_MOVES; i < MAX_MOVES; i++) {
+            for (const { x, y } of directions) {
+                const [newX, newY] = [this.x + x * i, this.y + y * i];
+                if (!this.isOutOfBounds(newX, newY)) {
+                    possibleMoves.push({ x: newX, y: newY });
+                }
+            }
+        }
+        return possibleMoves;
     }
-    for (i = 16; i < 48; i++) {
-        currentPosition[i] = { player: "none" };
-    }
-    for (i = 48; i < 56; i++) {
-        currentPosition[i] = { player: "white", piece: "pawn" };
-    }
-    currentPosition[56] = { player: "white", piece: "rook" };
-    currentPosition[57] = { player: "white", piece: "knight" };
-    currentPosition[58] = { player: "white", piece: "bishop" };
-    currentPosition[59] = { player: "white", piece: "queen" };
-    currentPosition[60] = { player: "white", piece: "king" };
-    currentPosition[61] = { player: "white", piece: "bishop" };
-    currentPosition[62] = { player: "white", piece: "knight" };
-    currentPosition[63] = { player: "white", piece: "rook" };
-    return currentPosition;
 }
+
+class Bishop extends Piece {
+    symbol = UNICODE_PIECES.bishop;
+    getPossibleMoves() {
+        const possibleMoves = [];
+        const directions = [
+            DIAGONAL_UP_LEFT,
+            DIAGONAL_UP_RIGHT,
+            DIAGONAL_DOWN_LEFT,
+            DIAGONAL_DOWN_RIGHT,
+        ];
+
+        const MIN_MOVES = 1;
+        const MAX_MOVES = 8;
+
+        for (let i = MIN_MOVES; i < MAX_MOVES; i++) {
+            for (const { x, y } of directions) {
+                const [newX, newY] = [this.x + x * i, this.y + y * i];
+                if (!this.isOutOfBounds(newX, newY)) {
+                    possibleMoves.push({ x: newX, y: newY });
+                }
+            }
+        }
+        return possibleMoves;
+    }
+}
+
+class Knight extends Piece {
+    symbol = UNICODE_PIECES.knight;
+    getPossibleMoves() {
+        const possibleMoves = [];
+        const directions = [
+            KNIGHT_UP_LEFT,
+            KNIGHT_UP_RIGHT,
+            KNIGHT_DOWN_LEFT,
+            KNIGHT_DOWN_RIGHT,
+            KNIGHT_LEFT_UP,
+            KNIGHT_LEFT_DOWN,
+            KNIGHT_RIGHT_UP,
+            KNIGHT_RIGHT_DOWN,
+        ];
+
+        for (const { x, y } of directions) {
+            const [newX, newY] = [this.x + x, this.y + y];
+            if (!this.isOutOfBounds(newX, newY)) {
+                possibleMoves.push({ x: newX, y: newY });
+            }
+        }
+        return possibleMoves;
+    }
+}
+
+class Queen extends Piece {
+    symbol = UNICODE_PIECES.queen;
+    getPossibleMoves() {
+        const possibleMoves = [];
+        const directions = [
+            UP,
+            DOWN,
+            LEFT,
+            RIGHT,
+            DIAGONAL_UP_LEFT,
+            DIAGONAL_UP_RIGHT,
+            DIAGONAL_DOWN_LEFT,
+            DIAGONAL_DOWN_RIGHT,
+        ];
+
+        const MIN_MOVES = 1;
+        const MAX_MOVES = 8;
+
+        for (let i = MIN_MOVES; i < MAX_MOVES; i++) {
+            for (const { x, y } of directions) {
+                const [newX, newY] = [this.x + x * i, this.y + y * i];
+                if (!this.isOutOfBounds(newX, newY)) {
+                    possibleMoves.push({ x: newX, y: newY });
+                }
+            }
+        }
+        return possibleMoves;
+    }
+}
+
+class King extends Piece {
+    symbol = UNICODE_PIECES.king;
+    getPossibleMoves() {
+        const possibleMoves = [];
+        const directions = [
+            UP,
+            DOWN,
+            LEFT,
+            RIGHT,
+            DIAGONAL_UP_LEFT,
+            DIAGONAL_UP_RIGHT,
+            DIAGONAL_DOWN_LEFT,
+            DIAGONAL_DOWN_RIGHT,
+        ];
+
+        for (const { x, y } of directions) {
+            const [newX, newY] = [this.x + x, this.y + y];
+            if (!this.isOutOfBounds(newX, newY)) {
+                possibleMoves.push({ x: newX, y: newY });
+            }
+        }
+        return possibleMoves;
+    }
+}
+
+class Pawn extends Piece {
+    symbol = UNICODE_PIECES.pawn;
+    hasMoved = false;
+    getPossibleMoves() {
+        // Placeholder, logic for the pawn movement WIP
+        // It's strange to code because of how attacking is different from moving
+        return "Not implemented, pawns are tricky!";
+    }
+}
+
+/*
+
+    Todo:
+     - Add logic for finding valid attacking moves
+     - Add logic for stopping the possible moves search in a specific direction once you hit a piece (piece collision)
+
+*/


### PR DESCRIPTION
Added piece class, and a subclass for each piece with a method to get the piece's possible moves.

Restructured script to use a 2D array as the chess board. The 2D array contains either an instance of a piece subclass or null. The piece instances contain relevant information about the piece in that slot.

Temporary functionality: clicking each piece console.logs an array of objects containing every possible x and y coordinate that piece can move to from its current position. Does not account for collision with other pieces yet.

CSS: Tweaked to use root variables, to prevent having to edit values in multiple places (Also some necessary restructure to account for how the playstate array is created now)