### PR TITLE
Pawn logic + temp "remove piece" feature for testing purposes

### DIFF
--- a/src/js/board.js
+++ b/src/js/board.js
@@ -57,13 +57,21 @@ function createTilesHTML() {
             tile.id = createIdString(row, col);
             tile.classList.add("tile");
             if (row % 2) tile.classList.add("odd");
-            tile.addEventListener("mousedown", () => {
+            tile.addEventListener("mousedown", (event) => {
                 if (currentPosition[row][col]) {
-                    console.log(
-                        currentPosition[row][col].getPossibleMoves(
-                            currentPosition
-                        )
-                    );
+                    if (event.altKey) {
+                        // Temporary event listener for testing purposes
+                        // If you hold Alt when clicking a piece, it deletes the piece!
+                        // Used for testing collision updates for now
+                        currentPosition[row][col] = null;
+                        drawCurrentPosition();
+                    } else {
+                        console.log(
+                            currentPosition[row][col].getPossibleMoves(
+                                currentPosition
+                            )
+                        );
+                    }
                 }
             });
             board.append(tile);
@@ -90,15 +98,17 @@ function drawCurrentPosition() {
      */
     for (let row = 0; row < currentPosition.length; row++) {
         for (let col = 0; col < currentPosition[0].length; col++) {
-            currentPiece = currentPosition[row][col];
+            const currentPiece = currentPosition[row][col];
+            const currentTileElement = getTileElement(row, col);
             if (currentPiece) {
-                const currentTile = getTileElement(row, col);
                 const pieceText = currentPiece.symbol;
                 const IS_WHITE = currentPiece.color === "white";
                 const IS_BLACK = !IS_WHITE;
-                currentTile.textContent = pieceText;
-                currentTile.classList.toggle("white", IS_WHITE);
-                currentTile.classList.toggle("black", IS_BLACK);
+                currentTileElement.textContent = pieceText;
+                currentTileElement.classList.toggle("white", IS_WHITE);
+                currentTileElement.classList.toggle("black", IS_BLACK);
+            } else {
+                currentTileElement.textContent = "";
             }
         }
     }

--- a/src/js/pieces.js
+++ b/src/js/pieces.js
@@ -40,12 +40,43 @@ class Piece {
         if (col < 0 || col > 7 || row < 0 || row > 7) return true;
         return false;
     }
+    getMovesFromMinMaxMoves(minMoves, maxMoves, directions, currentBoard) {
+        const possibleMoves = [];
+        for (let i = minMoves; i < maxMoves; i++) {
+            for (let j = 0; j < directions.length; j++) {
+                const { col, row, collided } = directions[j];
+                if (collided) continue;
+                const [newCol, newRow] = [
+                    this.col + col * i,
+                    this.row + row * i,
+                ];
+                if (this.isOutOfBounds(newCol, newRow)) continue;
+                const tileBeingChecked = currentBoard[newRow][newCol];
+                if (tileBeingChecked !== null) {
+                    if (tileBeingChecked.color !== this.color) {
+                        possibleMoves.push({
+                            col: newCol,
+                            row: newRow,
+                            attack: true,
+                        });
+                    }
+                    directions[j].collided = true;
+                } else {
+                    possibleMoves.push({
+                        x: newCol,
+                        y: newRow,
+                        attack: false,
+                    });
+                }
+            }
+        }
+        return possibleMoves;
+    }
 }
 
 class Rook extends Piece {
     symbol = UNICODE_PIECES.rook;
     getPossibleMoves(currentBoard) {
-        const possibleMoves = [];
         const directions = [
             { ...UP, collided: false },
             { ...DOWN, collided: false },
@@ -56,43 +87,18 @@ class Rook extends Piece {
         const MIN_MOVES = 1;
         const MAX_MOVES = 8;
 
-        for (let i = MIN_MOVES; i < MAX_MOVES; i++) {
-            for (let j = 0; j < directions.length; j++) {
-                const { col, row, collided } = directions[j];
-                if (collided) continue;
-                const [newCol, newRow] = [
-                    this.col + col * i,
-                    this.row + row * i,
-                ];
-                if (!this.isOutOfBounds(newCol, newRow)) {
-                    const tileBeingChecked = currentBoard[newRow][newCol];
-                    if (tileBeingChecked !== null) {
-                        if (tileBeingChecked.color !== this.color) {
-                            possibleMoves.push({
-                                col: newCol,
-                                row: newRow,
-                                attack: true,
-                            });
-                        }
-                        directions[j].collided = true;
-                    } else {
-                        possibleMoves.push({
-                            col: newCol,
-                            row: newRow,
-                            attack: false,
-                        });
-                    }
-                }
-            }
-        }
-        return possibleMoves;
+        return this.getMovesFromMinMaxMoves(
+            MIN_MOVES,
+            MAX_MOVES,
+            directions,
+            currentBoard
+        );
     }
 }
 
 class Bishop extends Piece {
     symbol = UNICODE_PIECES.bishop;
     getPossibleMoves(currentBoard) {
-        const possibleMoves = [];
         const directions = [
             { ...DIAGONAL_UP_LEFT, collided: false },
             { ...DIAGONAL_UP_RIGHT, collided: false },
@@ -103,36 +109,12 @@ class Bishop extends Piece {
         const MIN_MOVES = 1;
         const MAX_MOVES = 8;
 
-        for (let i = MIN_MOVES; i < MAX_MOVES; i++) {
-            for (let j = 0; j < directions.length; j++) {
-                const { col, row, collided } = directions[j];
-                if (collided) continue;
-                const [newCol, newRow] = [
-                    this.col + col * i,
-                    this.row + row * i,
-                ];
-                if (!this.isOutOfBounds(newCol, newRow)) {
-                    const tileBeingChecked = currentBoard[newRow][newCol];
-                    if (tileBeingChecked !== null) {
-                        if (tileBeingChecked.color !== this.color) {
-                            possibleMoves.push({
-                                col: newCol,
-                                row: newRow,
-                                attack: true,
-                            });
-                        }
-                        directions[j].collided = true;
-                    } else {
-                        possibleMoves.push({
-                            x: newCol,
-                            y: newRow,
-                            attack: false,
-                        });
-                    }
-                }
-            }
-        }
-        return possibleMoves;
+        return this.getMovesFromMinMaxMoves(
+            MIN_MOVES,
+            MAX_MOVES,
+            directions,
+            currentBoard
+        );
     }
 }
 
@@ -153,23 +135,22 @@ class Knight extends Piece {
 
         for (const { col, row } of directions) {
             const [newCol, newRow] = [this.col + col, this.row + row];
-            if (!this.isOutOfBounds(newCol, newRow)) {
-                const tileBeingChecked = currentBoard[newRow][newCol];
-                if (tileBeingChecked !== null) {
-                    if (tileBeingChecked.color !== this.color) {
-                        possibleMoves.push({
-                            col: newCol,
-                            row: newRow,
-                            attack: true,
-                        });
-                    }
-                } else {
+            if (this.isOutOfBounds(newCol, newRow)) continue;
+            const tileBeingChecked = currentBoard[newRow][newCol];
+            if (tileBeingChecked !== null) {
+                if (tileBeingChecked.color !== this.color) {
                     possibleMoves.push({
                         col: newCol,
                         row: newRow,
-                        attack: false,
+                        attack: true,
                     });
                 }
+            } else {
+                possibleMoves.push({
+                    col: newCol,
+                    row: newRow,
+                    attack: false,
+                });
             }
         }
         return possibleMoves;
@@ -202,24 +183,23 @@ class Queen extends Piece {
                     this.col + col * i,
                     this.row + row * i,
                 ];
-                if (!this.isOutOfBounds(newCol, newRow)) {
-                    const tileBeingChecked = currentBoard[newRow][newCol];
-                    if (tileBeingChecked !== null) {
-                        if (tileBeingChecked.color !== this.color) {
-                            possibleMoves.push({
-                                col: newCol,
-                                row: newRow,
-                                attack: true,
-                            });
-                        }
-                        directions[j].collided = true;
-                    } else {
+                if (this.isOutOfBounds(newCol, newRow)) continue;
+                const tileBeingChecked = currentBoard[newRow][newCol];
+                if (tileBeingChecked !== null) {
+                    if (tileBeingChecked.color !== this.color) {
                         possibleMoves.push({
-                            x: newCol,
-                            y: newRow,
-                            attack: false,
+                            col: newCol,
+                            row: newRow,
+                            attack: true,
                         });
                     }
+                    directions[j].collided = true;
+                } else {
+                    possibleMoves.push({
+                        x: newCol,
+                        y: newRow,
+                        attack: false,
+                    });
                 }
             }
         }
@@ -244,23 +224,22 @@ class King extends Piece {
 
         for (const { col, row } of directions) {
             const [newCol, newRow] = [this.col + col, this.row + row];
-            if (!this.isOutOfBounds(newCol, newRow)) {
-                const tileBeingChecked = currentBoard[newRow][newCol];
-                if (tileBeingChecked !== null) {
-                    if (tileBeingChecked.color !== this.color) {
-                        possibleMoves.push({
-                            col: newCol,
-                            row: newRow,
-                            attack: true,
-                        });
-                    }
-                } else {
+            if (this.isOutOfBounds(newCol, newRow)) continue;
+            const tileBeingChecked = currentBoard[newRow][newCol];
+            if (tileBeingChecked !== null) {
+                if (tileBeingChecked.color !== this.color) {
                     possibleMoves.push({
                         col: newCol,
                         row: newRow,
-                        attack: false,
+                        attack: true,
                     });
                 }
+            } else {
+                possibleMoves.push({
+                    col: newCol,
+                    row: newRow,
+                    attack: false,
+                });
             }
         }
         return possibleMoves;
@@ -270,17 +249,60 @@ class King extends Piece {
 class Pawn extends Piece {
     symbol = UNICODE_PIECES.pawn;
     hasMoved = false;
-    getPossibleMoves() {
-        // Placeholder, logic for the pawn movement WIP
-        // It's strange to code because of how attacking is different from moving
-        return "Not implemented, pawns are tricky!";
+    getPossibleMoves(currentBoard) {
+        /*
+         * This is absolutely horrendous, I just made it work to start.
+         * Will refactor later, for now it's functional though!
+         * It only accounts for first move, normal move, and diagonal attack.
+         * Does NOT account for en passant, as we haven't even implemented moving pieces yet
+         */
+        const MIN_MOVES = 1;
+        const MAX_MOVES = this.hasMoved ? 2 : 3;
+        const moveDirectionsWhite = [{ ...UP, collided: false }];
+        const moveDirectionsBlack = [{ ...DOWN, collided: false }];
+        const attackDirectionsWhite = [
+            { ...DIAGONAL_UP_LEFT, ...DIAGONAL_UP_RIGHT },
+        ];
+        const attackDirectionsBlack = [
+            { ...DIAGONAL_DOWN_LEFT },
+            { ...DIAGONAL_DOWN_RIGHT },
+        ];
+        const moveDirections =
+            this.color === "white" ? moveDirectionsWhite : moveDirectionsBlack;
+        const attackDirections =
+            this.color === "white"
+                ? attackDirectionsWhite
+                : attackDirectionsBlack;
+
+        const possibleMoves = this.getMovesFromMinMaxMoves(
+            MIN_MOVES,
+            MAX_MOVES,
+            moveDirections,
+            currentBoard
+        );
+        const possibleAttacks = this.getPossibleAttacks(
+            attackDirections,
+            currentBoard
+        );
+        return [...possibleMoves, ...possibleAttacks];
+    }
+    getPossibleAttacks(attackDirections, currentBoard) {
+        const possibleAttacks = [];
+        for (const { col, row } of attackDirections) {
+            const [newCol, newRow] = [this.col + col, this.row + row];
+            if (this.isOutOfBounds(newCol, newRow)) continue;
+            const tileBeingChecked = currentBoard[newRow][newCol];
+            if (
+                tileBeingChecked !== null &&
+                tileBeingChecked.color !== this.color
+            ) {
+                possibleAttacks.push({
+                    col: newCol,
+                    row: newRow,
+                    attack: true,
+                });
+            }
+        }
+        return possibleAttacks;
     }
 }
-
-/*
-
-    Todo:
-     - Add logic for finding valid attacking moves
-     - Add logic for stopping the possible moves search in a specific direction once you hit a piece (piece collision)
-
-*/


### PR DESCRIPTION
Basic logic for getting pawns is functional, but definitely not optimal yet. It does not account for en passant yet, as we don't have a way to move pieces at all yet.

Also refactored big parts of the pieces' getPossibleMoves method to use a helper method in the parent Piece class to prevent repeating similar calculations in code.

Temp feature for testing collision of backline pieces: Alt + click to delete a piece on the board!