### PR TITLE
Pawn refactor + show possible moves

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -47,3 +47,24 @@ body {
         -1px 1px 0 white;
     color: hsl(0, 0%, 0%);
 }
+
+.possible-attack {
+    box-shadow: inset 0 0 0 50px rgba(255, 0, 0, 0.45);
+}
+
+.possible-attack:hover {
+    box-shadow: inset 0 0 0 50px rgba(255, 0, 0, 0.5), inset 0 0 8px red;
+}
+
+.possible-move {
+    box-shadow: inset 0 0 0 50px rgba(0, 255, 64, 0.35);
+}
+
+.possible-move:hover {
+    box-shadow: inset 0 0 0 50px rgba(0, 255, 64, 0.45),
+        inset 0 0 8px rgb(0, 255, 0);
+}
+
+.selected-piece {
+    box-shadow: inset 0 0 0 50px rgba(0, 195, 255, 0.45);
+}

--- a/src/js/board.js
+++ b/src/js/board.js
@@ -58,24 +58,27 @@ function createTilesHTML() {
             tile.classList.add("tile");
             if (row % 2) tile.classList.add("odd");
             tile.addEventListener("mousedown", (event) => {
-                if (currentPosition[row][col]) {
-                    if (event.altKey) {
-                        // Temporary event listener for testing purposes
-                        // If you hold Alt when clicking a piece, it deletes the piece!
-                        // Used for testing collision updates for now
-                        currentPosition[row][col] = null;
-                        drawCurrentPosition();
-                    } else {
-                        console.log(
-                            currentPosition[row][col].getPossibleMoves(
-                                currentPosition
-                            )
-                        );
-                    }
-                }
+                handleClick(event, row, col);
             });
             board.append(tile);
         }
+    }
+}
+
+function handleClick(event, row, col) {
+    clearPossibleMovesClasses();
+    if (!currentPosition[row][col]) return;
+    if (event.altKey) {
+        // Temporary event listener for testing purposes
+        // If you hold Alt when clicking a piece, it deletes the piece!
+        // Used for testing collision updates for now
+        currentPosition[row][col] = null;
+        drawCurrentPosition();
+    } else {
+        const possibleMoves =
+            currentPosition[row][col].getPossibleMoves(currentPosition);
+        showPossibleMoves(possibleMoves);
+        getTileElement(row, col).classList.add("selected-piece");
     }
 }
 
@@ -111,5 +114,28 @@ function drawCurrentPosition() {
                 currentTileElement.textContent = "";
             }
         }
+    }
+}
+
+function showPossibleMoves(possibleMoves) {
+    console.log(possibleMoves);
+    if (!possibleMoves.length) return;
+    for (const { row, col, attack } of possibleMoves) {
+        const tile = getTileElement(row, col);
+        const classString = attack ? "possible-attack" : "possible-move";
+        tile.classList.add(classString);
+    }
+}
+
+function clearPossibleMovesClasses() {
+    const tilesToClear = document.querySelectorAll(
+        ".possible-move, .possible-attack, .selected-piece"
+    );
+    for (const tile of tilesToClear) {
+        tile.classList.remove(
+            "possible-move",
+            "possible-attack",
+            "selected-piece"
+        );
     }
 }


### PR DESCRIPTION
Refactored the logic for getting possible pawn moves, still a bit clunky but a lot better than it was before.

Changed the for loop condition from `<` to `<=`. Corrected all max moves accordingly (because a piece will never move 8 tiles, 7 tiles is the max if you're on the edge of the board, because the piece itself takes up 1 tile.)

Now uses the returned object from `getPossibleMoves` to visualize the tiles you can interact with. Does not include logic for actually moving any pieces yet.